### PR TITLE
Add /CNAME to the exclude path list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,8 @@ exports = module.exports = function() {
   
   var pathExcludes = [
     '/.htaccess',
-    '/robots.txt'
+    '/robots.txt',
+    '/CNAME'
   ];
   
   var extExcludes = [


### PR DESCRIPTION
Tiny addition to avoid getting the CNAME file path in the sitemap.
